### PR TITLE
rt.cpan.org#42122 - untaint $content before using it in 'truncate'

### DIFF
--- a/lib/File/NFSLock.pm
+++ b/lib/File/NFSLock.pm
@@ -209,8 +209,11 @@ sub new {
           $content .= $line;          # Save valid locks
         }
 
+        ### Untaint $content
+        ($content) = ($content =~ /\A(.*)\z/);
+
         ### Save any valid locks or wipe file.
-        if( length($content) ){
+        if( defined($content) && length($content) ){
           seek     $fh, 0, 0;
           print    $fh $content;
           truncate $fh, length($content);
@@ -410,8 +413,11 @@ sub do_unlock_shared ($) {
     $content .= $line;
   }
 
+  ### Untaint $content
+  ($content) = ($content =~ /\A(.*)\z/);
+
   ### other shared locks exist
-  if( length($content) ){
+  if( defined($content) && length($content) ){
     seek     $fh, 0, 0;
     print    $fh $content;
     truncate $fh, length($content);


### PR DESCRIPTION
See my post in https://rt.cpan.org/Ticket/Display.html?id=42122, posted Thu Jan 15 11:00:14 2015.

Using perl scripts in taint mode served by an Apache web servers produces warnings when the variable $content is read from:

```
Insecure dependency in truncate while running with -T switch at /tmp/locktest/File/NFSLock.pm line 417, <$fh> line 2.
\t(in cleanup) Insecure dependency in truncate while running with -T switch at /tmp/locktest/File/NFSLock.pm line 417, <$fh> line 2.
```

The merge request untaints $content before using it in 'truncate'.